### PR TITLE
Animation User-Friendliness Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Thumbs.db
 ######################
 sysplotter_config.mat
 sysplotter_data
+
+# UserFiles #
+#############
+UserFiles/*
+!UserFiles/GenericUser

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ sysplotter_data
 #############
 UserFiles/*
 !UserFiles/GenericUser
+
+# Animation Output #
+####################
+ProgramFilesAnimation/saved\ animation

--- a/ProgramFiles/Animation/robot_drawing_tools/robot_drawing_tools/create_backbone.m
+++ b/ProgramFiles/Animation/robot_drawing_tools/robot_drawing_tools/create_backbone.m
@@ -1,0 +1,53 @@
+function robot = create_backbone(parent,data_source,system_name,backbone,orientation_color)
+
+%Basic object
+object_primative = struct('parent',parent,...
+	'type',[],...
+    'local_geom',struct('vertices',[],'scaling',[],'sidelengths',[],'radius',[],'corner_rad',[]),...
+    'ref_pos', struct('now',[],...
+        'last',[]...
+        ),...
+    'geom',struct('vertices',[]...
+        ,'line_eq',struct('matrix',[])...
+        ,'segments',[]...
+        ),...
+    'graphics',struct('handle',[],'fill',[],'edge',[])...
+    );
+
+%To do: make it work for the other kind of backbone spec
+%Get a serpenoid body
+body_local = fatbackbone_from_curvature_bases(backbone,[0;0],1,.2/6);
+% body_local = fatbackbone_from_curvature_bases_triangular({@serpenoid_1;@serpenoid_2},[0;0],1,.2/6);
+% body_local1 = backbone_from_curvature_bases({@serpenoid_1;@serpenoid_2},[0;0],1);
+
+%%%
+%build the robot
+
+%%
+%Make the polygons for the links (really just one curved link for drawing
+%purposes)
+robot.links = object_primative;
+
+%Size of links
+link_scale = 1;
+
+for i = 1:size(robot.links,1)
+	robot.links(i).type = 'polygon';
+	robot.links(i).local_geom.vertices =  link_scale * body_local;
+	robot.links(i).graphics.fill = {'FaceColor','w'};
+	robot.links(i).graphics.edge = {'EdgeColor','k','LineWidth',1};
+end
+
+
+
+%make the center-dot
+robot.center = line('XData',[],'YData',[],'Color','k','LineStyle','none','Marker','o','MarkerSize',10,'MarkerFaceColor','k');
+
+%make the orientation line
+if ~exist('orientation_color','var')
+	orientation_color = [110 110 110]/255;
+end
+robot.orientation = line('XData',[],'YData',[],'Color',orientation_color,'LineStyle','-','Marker','none','LineWidth',2);
+
+% Identify the system file containing optimal coordinate information
+robot.sysdata = fullfile(data_source,['sysf_' system_name '_calc']);

--- a/ProgramFiles/Animation/robot_drawing_tools/robot_drawing_tools/place_backbone.m
+++ b/ProgramFiles/Animation/robot_drawing_tools/robot_drawing_tools/place_backbone.m
@@ -1,0 +1,78 @@
+function robot = place_backbone(robot,config,coords,backbone)
+%set the positions of the links and wheelsets of the robot in a given
+%configuration and coordinate scheme
+
+alpha_1 = config.alpha_1;
+alpha_2 = config.alpha_2;
+x = config.x;
+y = config.y;
+theta = config.theta;
+
+%To do: make it work for the other kind of backbone spec
+
+% Rebuild the backbone
+body_local = fatbackbone_from_curvature_bases(backbone,[alpha_1;alpha_2],1,.2/6);
+% body_local = fatbackbone_from_curvature_bases({@constant_curvature_1;@constant_curvature_2},[alpha_1;alpha_2],1,.2/6);
+% body_local = fatbackbone_from_curvature_bases_triangular({@serpenoid_1;@serpenoid_2},[alpha_1;alpha_2],1,.2/6);
+robot.links.local_geom.vertices =  body_local;
+
+		
+%Build the transform for the position
+ref_pos = vec_to_mat_se2([x y theta]);
+
+robot.ref_pos = [x y theta];
+
+%Build the transform from the body frame to the middle link frame
+switch coords
+	
+	case 'original'
+		
+		coord_pos = eye(3);
+		
+	case 'mean'
+		
+		beta_theta = (alpha_2-alpha_1)/3;
+		
+		coord_pos = vec_to_mat_se2([0 0 -beta_theta]);
+		
+	case 'optimized'
+		
+		load(robot.sysdata,'s')
+		
+		beta_x = interpn(s.grid.eval{1}, s.grid.eval{2}, s.B_optimized.eval.Beta{1},alpha_1,alpha_2);
+		beta_y = interpn(s.grid.eval{1}, s.grid.eval{2}, s.B_optimized.eval.Beta{2},alpha_1,alpha_2);
+		beta_theta = interpn(s.grid.eval{1}, s.grid.eval{2}, s.B_optimized.eval.Beta{3},alpha_1,alpha_2);
+		
+		coord_pos = inv(vec_to_mat_se2([beta_x, beta_y, beta_theta]));
+		
+	case 'original-to-mean'
+		
+		beta_theta = (alpha_2-alpha_1)/3*config.percentage;
+		
+		coord_pos = vec_to_mat_se2([0 0 -beta_theta]);
+		
+	otherwise
+		
+		error('Unsupported coordinate set');
+		
+end
+
+%%%%%%
+%Get the world-positions of the robot elements
+	
+linkposmat = ref_pos*coord_pos;
+
+
+%Pull the position vectors back out
+linkpos = mat_to_vec_se2(linkposmat)';
+
+%Assign the link positions to the link and wheelset polygons
+for i = 1:size(linkpos,2)
+	
+	robot.links(i).ref_pos.now = deal(linkpos(:,i));
+
+end
+
+% %Put the center-dot at the ref position
+% set(robot.center,'XData',x,'YData',y)
+

--- a/ProgramFiles/sysplotter_config_fcns/animatebutton_gui2_Callback.m
+++ b/ProgramFiles/sysplotter_config_fcns/animatebutton_gui2_Callback.m
@@ -7,7 +7,7 @@ function animatebutton_gui2_Callback(hObject, eventdata, handles)
 % Get the number of gaits
 info_needed.Number_gaits = str2double(get(handles.number_input,'string'));
 
-% Gait the Frame rate
+% Get the Frame rate
 info_needed.Framerate = str2double(get(handles.framrate,'string'));
 
 
@@ -21,6 +21,14 @@ current_system = system_names{system_index};
 % Remove the "sysf_" from the system
 current_system2 = current_system(6:end);
 
+%%%%%%%%%%%%%%%% Select an animate system function
+
+%Load system to check if there's a BackboneShape field
+configfile = './sysplotter_config';
+load(configfile,'datapath')
+sysfile = fullfile(datapath, current_system);
+load(sysfile,'s')
+    
 % Check whether it is 3-links, 4-inks, serpenoid ot triangular
 if findstr(current_system2,'serpenoid')
     
@@ -38,11 +46,19 @@ elseif findstr(current_system2,'floating')
     
     animate_system = @animate_floating_snake;
     
+elseif isfield(s,'BackboneShape')
+% If there isn't a specialized animation function but the system has a
+% geometry specified, use animate_backbone
+
+    animate_system = @animate_backbone;
+
 else
     
     animate_system = @animate_3_links_swimmer;
     
 end
+
+%%%%%%%%%%%%%%%%
 
 % Get the shape change info
 shch_index = get(handles.old.shapechangemenu,'Value');
@@ -57,16 +73,12 @@ current_shch2 = current_shch(7:end);
 current_directory = pwd;
 info_needed.current_directory = current_directory;
 
-[pathstr1,name1,ext1] = fileparts(current_directory);
-[pathstr2,name2,ext2] = fileparts(pathstr1);
+info_needed.UserFile_path = datapath;
 
-
-info_needed.UserFile_path = fullfile(pathstr1,'UserFiles\GenericUser\sysplotter_data');
-
-
-
+% Passed to animation() for use in movie export filename
 info_needed.current_system2 = current_system2;
 info_needed.current_shch2 = current_shch2;
 
 % Run the animation
 animate_system([],info_needed)
+end

--- a/UserFiles/GenericUser/Systems/sysf_flyingsnakebot_smallrange.m
+++ b/UserFiles/GenericUser/Systems/sysf_flyingsnakebot_smallrange.m
@@ -1,0 +1,90 @@
+function output = sysf_flyingsnakebot_smallrange(input_mode,pathnames)
+
+	% Default arguments
+	if ~exist('input_mode','var')
+		
+		input_mode = 'initialize';
+		
+	end
+		
+	%%%%%%%
+	
+	switch input_mode
+
+		case 'name'
+
+			output = 'Flying SnakeBot: 4.7 Curvature Limit'; % Display name
+
+		case 'dependency'
+%need to change these?
+			output.dependency = fullfile(pathnames.sysplotterpath,...
+                {'Utilities/curvature_mode_toolbox/backbone_from_curvature_bases.m',...
+				'Utilities/curvature_mode_toolbox/curvatures/serpenoid_1.m',...
+				'Utilities/curvature_mode_toolbox/curvatures/serpenoid_2.m',...
+				'Utilities/LowRE_toolbox/LowRE_dissipation_metric_from_curvature_bases.m',...
+				'Utilities/LowRE_toolbox/Inertial_local_connection_from_curvature_bases.m'});
+
+		case 'initialize'
+            
+            %Functional representation of backbone shape
+            s.BackboneShape = {@constant_curvature_1;@constant_curvature_2};
+            
+			%Functional representation of local connection
+			s.A_num = @Conn_num;
+
+            %Range of motion toggle
+            rangeofmotion=4.7;
+            
+			%%%
+			%Processing details
+
+			%Range over which to evaluate connection
+            %The 1.1 is to hide the ugly boundary vectors
+			%s.grid_range = [-1,1,-1,1]*12;
+            s.grid_range = [-1,1,-1,1]*(rangeofmotion+0.5);
+
+			%densities for various operations
+			s.density.vector = [11 11]; %density to display vector field
+			s.density.scalar = [21 21]; %density to display scalar functions
+			s.density.eval = [51 51];   %density for function evaluations   %%%%%%%%can change this for gaits 51?
+			s.finite_element_density = 11;
+% change this from LowRE to Inertial!!
+%oh it looks like there's only "inTERNal" hmmm
+%it runs while commented out still. but what are the default values?
+			% power metric
+			%s.metric = @(x,y) LowRE_dissipation_metric_from_curvature_bases...
+			%	({@serpenoid_1;@serpenoid_2},[x;y],1,1,2);  % @(x,y) eye(2);%
+
+			%%%
+			%Display parameters
+
+			%shape space tic locations
+			%s.tic_locs.x = [-2 -1 0 1 2]*6;
+			%s.tic_locs.y = [-2 -1 0 1 2]*6;
+			s.tic_locs.x = [-2 -1 0 1 2]*rangeofmotion/2;
+			s.tic_locs.y = [-2 -1 0 1 2]*rangeofmotion/2;
+
+
+			%%%%
+			%Save the system properties
+			output = s;
+
+
+	end
+
+end
+
+%This is the connection funciton evaluated at a certain point!!!
+function [Ar]=Conn_num(a1,a2)
+
+        %Original:
+        % Inputs:kappa_basis_input,r,L,c,drag_ratio
+		%Ar =  LowRE_local_connection_from_curvature_bases({@serpenoid_1;@serpenoid_2},[a1;a2],1,1,2);
+        
+        %Modified:
+        % Inputs:  kappa_basis_input,r,L,density
+        %OH I can only get it to run without crashing if I just don't
+        %specify a density at all. I guess that works?
+ 		Ar =  Inertial_local_connection_from_curvature_bases({@constant_curvature_1;@constant_curvature_2},[a1;a2],1); %length of snake (should stay 1 normally)
+        
+end


### PR DESCRIPTION
- Instead of exporting images of frames to be compiled into a video later, animation.m now uses the '-RGBImage' option of print() to collect frames in a datastructure and export a .avi movie within the script.
- Instead of making new animation functions for each new system, it is now possible to add a field s.BackboneShape to the system. This is a cell array of functions that describe the geometry. s.BackboneShape will be passed through to the animation functions, and only the sysf file itself needs to be created.
- Added a system flyingsnakebot_smallrange to GenericUser as an example of using s.BackboneShape
- Some changes need to be made to the other animate_[systemname] functions to be compatible with the new animation.m. I've changed animate_3_link_swimmer.m to work, so that can be used as a template for the others.

TODO:
- Rename s.BackboneShape to s.Geometry
- Add functionality for different kinds of geometry like absolute functions or n-link swimmers