### PR TITLE
Sysplotter extension to systems with 4 shape variables and plotting DA for systems with 2 shape variables

### DIFF
--- a/ProgramFiles/Geometry/ContinuousBackbone/backbone_conversion_factors.m
+++ b/ProgramFiles/Geometry/ContinuousBackbone/backbone_conversion_factors.m
@@ -165,7 +165,7 @@ switch baseframe
             %%%
             % First, strip off sysf_ if it was included by the user
 
-            if startsWith(baseframe,'sysf_')
+            if strncmp(baseframe,'sysf_',5)
                 baseframe1 = baseframe(6:end);
             else
                 baseframe1 = baseframe;

--- a/ProgramFiles/Utilities/hypercubemesh/hypercube_element_shape_functions.m
+++ b/ProgramFiles/Utilities/hypercubemesh/hypercube_element_shape_functions.m
@@ -6,13 +6,14 @@ function [shape_functions, shape_dfunctions] = hypercube_element_shape_functions
 	shape_dfunctions = cell(2^N,N);
 	
 	% Set up the node orderings for the shape functions, up to 3d elements
-	ordering(:,1) = [-1, 1, 1,-1,-1, 1, 1,-1]';
-	ordering(:,2) = [-1,-1, 1, 1,-1,-1, 1, 1]';
-	ordering(:,3) = [-1,-1,-1,-1, 1, 1, 1, 1]';
+	ordering(:,1) = [-1, 1, 1,-1,-1, 1, 1,-1,-1, 1, 1,-1,-1, 1, 1,-1]';
+	ordering(:,2) = [-1,-1, 1, 1,-1,-1, 1, 1,-1,-1, 1, 1,-1,-1, 1, 1]';
+	ordering(:,3) = [-1,-1,-1,-1, 1, 1, 1, 1,-1,-1,-1,-1, 1, 1, 1, 1]';
+    ordering(:,4) = [-1,-1,-1,-1,-1,-1,-1,-1, 1, 1, 1, 1, 1, 1, 1, 1]';
 	
 	% error if the ordering hasn't been specified to high enough dimension
-	if N>3
-		error('This function only specified up to 3 dimensions so far')
+	if N>4
+		error('This function only specified up to 4 dimensions so far')
 	end
 	
 	% Turn the ordering into a cell array for processing inside the shape

--- a/ProgramFiles/Utilities/hypercubemesh/hypercube_mesh.m
+++ b/ProgramFiles/Utilities/hypercubemesh/hypercube_mesh.m
@@ -44,10 +44,32 @@ function [nodes,cubes] = hypercube_mesh(grid)
 			cubes(:,6) = reshape(node_nums(2:l(1),1:l(2)-1,2:l(3)),n_cubes,1);
 			cubes(:,7) = reshape(node_nums(2:l(1),2:l(2),2:l(3)),n_cubes,1);
 			cubes(:,8) = reshape(node_nums(1:l(1)-1,2:l(2),2:l(3)),n_cubes,1);
+            
+        case 4
+            
+ 			cubes(:,1) = reshape(node_nums(1:l(1)-1,1:l(2)-1,1:l(3)-1,1:l(4)-1),n_cubes,1);
+			cubes(:,2) = reshape(node_nums(2:l(1),1:l(2)-1,1:l(3)-1,1:l(4)-1),n_cubes,1);
+			cubes(:,3) = reshape(node_nums(2:l(1),2:l(2),1:l(3)-1,1:l(4)-1),n_cubes,1);
+			cubes(:,4) = reshape(node_nums(1:l(1)-1,2:l(2),1:l(3)-1,1:l(4)-1),n_cubes,1);
+			
+			cubes(:,5) = reshape(node_nums(1:l(1)-1,1:l(2)-1,2:l(3),1:l(4)-1),n_cubes,1);
+			cubes(:,6) = reshape(node_nums(2:l(1),1:l(2)-1,2:l(3),1:l(4)-1),n_cubes,1);
+			cubes(:,7) = reshape(node_nums(2:l(1),2:l(2),2:l(3),1:l(4)-1),n_cubes,1);
+			cubes(:,8) = reshape(node_nums(1:l(1)-1,2:l(2),2:l(3),1:l(4)-1),n_cubes,1);           
+
+			cubes(:,9) = reshape(node_nums(1:l(1)-1,1:l(2)-1,1:l(3)-1,2:l(4)),n_cubes,1);
+			cubes(:,10) = reshape(node_nums(2:l(1),1:l(2)-1,1:l(3)-1,2:l(4)),n_cubes,1);
+			cubes(:,11) = reshape(node_nums(2:l(1),2:l(2),1:l(3)-1,2:l(4)),n_cubes,1);
+			cubes(:,12) = reshape(node_nums(1:l(1)-1,2:l(2),1:l(3)-1,2:l(4)),n_cubes,1);
+			
+			cubes(:,13) = reshape(node_nums(1:l(1)-1,1:l(2)-1,2:l(3),2:l(4)),n_cubes,1);
+			cubes(:,14) = reshape(node_nums(2:l(1),1:l(2)-1,2:l(3),2:l(4)),n_cubes,1);
+			cubes(:,15) = reshape(node_nums(2:l(1),2:l(2),2:l(3),2:l(4)),n_cubes,1);
+			cubes(:,16) = reshape(node_nums(1:l(1)-1,2:l(2),2:l(3),2:l(4)),n_cubes,1);
 			
 		otherwise
 			
-			error('hypercube_mesh not yet implemented for N>3 dimensions');
+			error('hypercube_mesh not yet implemented for N>4 dimensions');
 			
 	end			
 			

--- a/ProgramFiles/sys_calcpath_fcns/find_g.m
+++ b/ProgramFiles/sys_calcpath_fcns/find_g.m
@@ -3,7 +3,7 @@ function p = find_g(s,p)
 % change in p over the system in s
 
 	% Set the initial values of the integrals
-	n_dim = size(s.dA,1);
+	n_dim = size(s.vecfield.eval.content.Avec_optimized,1);
 	
 	% Iterate over the paths
 	n_paths = length(p.phi_fun);

--- a/ProgramFiles/sys_calcsystem.m
+++ b/ProgramFiles/sys_calcsystem.m
@@ -51,8 +51,11 @@ function output = sys_calcsystem(input_mode,systemfilename)
 			%Calculate the constraint curvature functions from the connection
 			s = calc_constraint_curvature(s);
             
-            %Build a stretch function corresponding to the metric
-            s = calc_stretch_functions(s);
+            %Build a stretch function corresponding to the metric only if
+            %the system is 2 dimensional
+            if length(s.grid_range)/2<3
+                s = calc_stretch_functions(s);
+            end
 						
 			%Save out the updated system properties
 			save(outfile,'s')

--- a/ProgramFiles/sys_calcsystem_fcns/create_grids.m
+++ b/ProgramFiles/sys_calcsystem_fcns/create_grids.m
@@ -2,7 +2,7 @@
 function s = create_grids(s)
 
     %list of grids that will be made
-    grid_list = {'vector','scalar','eval','metric_eval','metric_display'};
+    grid_list = {'vector','scalar','eval','metric_eval','metric_display','finite_element'};
         
     % Create a cell array to hold the grid primitives
 	gridprim = cell(length(s.grid_range)/2,1);

--- a/ProgramFiles/sys_calcsystem_fcns/evaluate_connection.m
+++ b/ProgramFiles/sys_calcsystem_fcns/evaluate_connection.m
@@ -14,7 +14,7 @@ function s = evaluate_connection(s)
     s = evaluate_tensors_in_system_file(s,component_list,{'eval','eval'},'vecfield');
     
     % resample the fields at a low density for vector field display
-    s = resample_tensors_in_system_file(s,component_list,'eval',{'display','vector'},'vecfield');
+    s = resample_tensors_in_system_file(s,component_list,'eval',{'display','vector';'finite_element','finite_element'},'vecfield');
         
     
     

--- a/ProgramFiles/sys_draw_fcns/set_tics_shapespace.m
+++ b/ProgramFiles/sys_draw_fcns/set_tics_shapespace.m
@@ -1,4 +1,4 @@
-function set_tics_shapespace(ax,s,convert)
+function set_tics_shapespace(ax,s)
 %place the tic marks
     
     %set the tic fontsize

--- a/ProgramFiles/sys_draw_fcns/vfield_draw.m
+++ b/ProgramFiles/sys_draw_fcns/vfield_draw.m
@@ -254,7 +254,7 @@ function plot_info = vfield_draw(s,p,plot_info,sys,shch,resolution)
         label_shapespace_axes(ax,[],plot_info.stretch);
 		
         %Set the tic marks
-        set_tics_shapespace(ax,s,s.convert);
+        set_tics_shapespace(ax,s);
         
         %If there's a shape change involved, plot it
         if ~strcmp(shch,'null')


### PR DESCRIPTION
1. Backend works for systems with up to 4 shape variable.
2. s.convert is calculated only for system with 2 shape variables.
3. Can now adjust finite element density.
4. DA for systems with three shape variables plots the projection of the constraint curvature function onto the plane most aligned with the constraint curvature at the origin.
5.set_tics_shapespace doesn't need s.convert as an input argument. Removed the argument so that it works for systems with more than 2 shape variables.