### PR TITLE
Kinematic Error Chain

### DIFF
--- a/ProgramFiles/Geometry/NLinkChain/error_chain.m
+++ b/ProgramFiles/Geometry/NLinkChain/error_chain.m
@@ -1,0 +1,104 @@
+% does chain construction and error visualization using GroupElements
+function end_error_lae = error_chain(geometry, configuration, order)
+    % inputs:
+        % geometry:
+            % elements: cell array of GroupElements encoding transforms
+            % types: cell array of characters encoding transform types
+                % 'j': joint
+                % 'e': error
+                % 'l': link (can really be anything)
+        % configuration: all scalar/sym arrays, multiplying their
+        % respective transform types
+            % links
+            % joints
+            % errors
+        % order: integer order for both Taylor Series and BCH approx.
+    
+    %% input sanitation
+    % geometry checking
+    if ~exist('geometry', 'var')
+        error('error_chain: geometry must be provided');
+    end
+    if ~isfield(geometry, 'elements') || ~isfield(geometry, 'types')
+        error('error_chain: geometry requires both elements and types');
+    end
+    if ~all(cellfun(@(A) isa(A, 'GroupElement'), geometry.elements))
+        error('error_chain: geometry elements must be GroupElements')
+    end
+    if ~all(cellfun(@(A) isa(A, 'char'), geometry.types))
+        error('error_chain: geometry types must be characters')
+    end
+    if ~exist('order', 'var')
+        warning('error_chain: order not provided; assuming order 1');
+        order = 1;
+    end
+    % create logical arrays for easy indexing
+    link_logical = cellfun(@(c) strcmp(c,'l'), geometry.types);
+    joint_logical = cellfun(@(c) strcmp(c,'j'), geometry.types);
+    error_logical = cellfun(@(c) strcmp(c,'e'), geometry.types);
+    % confirm existence of configuration
+    if ~exist('configuration', 'var')
+        configuration = struct;
+    end
+    if any(link_logical) && ~isfield(configuration, 'links')
+        configuration.links = ones(1, sum(link_logical));
+    end
+    if any(joint_logical) && ~isfield(configuration, 'joints')
+        configuration.joints = ones(1, sum(joint_logical));
+    end
+    if any(error_logical) && ~isfield(configuration, 'errors')
+        configuration.errors = ones(1, sum(error_logical));
+    end
+    
+    %% construction of Lie Algebra elements
+    % get corresponding algebra elements from input group elements
+    algebras = cell(1,length(geometry.elements));
+    for i = 1:length(geometry.elements)
+        % may be able to write as cellfun
+        algebras{i} = geometry.elements{i}.to_AlgebraElement();
+    end
+    % apply scaling after log for cleanliness (is this admissible?)
+    % this isn't very clean, but it's clear
+    links = algebras(link_logical);
+    joints = algebras(joint_logical);
+    errors = algebras(error_logical);
+    for l = 1:length(links)
+        links{l} = AlgebraElement(configuration.links(l)*links{l}.vector);
+    end
+    for j = 1:length(joints)
+        joints{j} = AlgebraElement(configuration.joints(j)*joints{j}.vector);
+    end
+    for e = 1:length(errors)
+        errors{e} = AlgebraElement(configuration.errors(e)*errors{e}.vector);
+    end
+    algebras(link_logical) = links;
+    algebras(joint_logical) = joints;
+    algebras(error_logical) = errors;
+    
+    %% symbolic math for error approximation
+    % create symbolic error term
+    dim = length(algebras{1}.vector);
+    sigma_vec = sym('sigma', [1, dim]);
+    sigma = AlgebraElement(sigma_vec);
+    % use BCH to write LHS, RHS
+    lhs_elements = [algebras(~error_logical) {sigma}];
+    LHS = BCH_n_elements(lhs_elements, order);
+    RHS = BCH_n_elements(algebras, order);
+    % solve for error, sigma
+    sigma_soln_struct = solve(LHS.vector == RHS.vector, sigma_vec);
+    sigma_soln_vec = subs(sigma_vec, sigma_soln_struct);
+    end_error_lae = AlgebraElement(sigma_soln_vec);
+    % exponentiate with T.S. approx.
+    end_error_lge = end_error_lae.to_GroupElement_Taylor(order);
+    
+    %% break solution apart in terms of errors
+    % break into terms: linear, bilinear, quadratic... (in ea. err)
+    % plot contributions (in an interactable plot environment?)
+    
+    % existing outputs:
+        % link configurations
+        % Jacobians of each link
+    % new outputs:
+        % error term(s)?
+        % plotted errors
+end

--- a/ProgramFiles/Geometry/NLinkChain/error_chain.m
+++ b/ProgramFiles/Geometry/NLinkChain/error_chain.m
@@ -1,18 +1,43 @@
 % does chain construction and error visualization using GroupElements
-function end_error_lae = error_chain(geometry, configuration, order)
+function [end_error_lae,...
+          end_error_lge,...
+          expected_terms,...
+          sep_error_terms,...
+          joint_configurations,...
+          J] = error_chain(geometry, configuration, order, truncate_to)
     % inputs:
         % geometry:
             % elements: cell array of GroupElements encoding transforms
             % types: cell array of characters encoding transform types
                 % 'j': joint
                 % 'e': error
-                % 'l': link (can really be anything)
+                % 'l': link
         % configuration: all scalar/sym arrays, multiplying their
         % respective transform types
             % links
             % joints
             % errors
         % order: integer order for both Taylor Series and BCH approx.
+        % truncate_to: integer degree for term truncation
+    % outputs:
+        % end_error_lae:
+            % AlgebraElement encoding the joint error propogated to the end
+            % effector
+        % end_error_lge:
+            % GroupElement after exponentiation of end_error_lae using
+            % taylor series approximation to supplied order
+        % expected_terms:
+            % cell array of polynomial terms in any supplied error 
+            % variables, up to degree supplied by truncate_to
+        % sep_error_terms:
+            % cell array of terms equivalent to end_error_lge, but 
+            % separated into quantities manifested as expected_terms
+        % joint_configurations:
+            % matrix of nominal world space configurations of supplied
+            % joints
+        % J:
+            % 3D array (pages of matrices) containing Jacobians of supplied
+            % joints
     
     %% input sanitation
     % geometry checking
@@ -32,6 +57,10 @@ function end_error_lae = error_chain(geometry, configuration, order)
         warning('error_chain: order not provided; assuming order 1');
         order = 1;
     end
+    if ~exist('truncate_to', 'var')
+        warning('error_chain: truncate_to not provided; truncated to degree 1');
+        truncate_to = 1;
+    end
     % create logical arrays for easy indexing
     link_logical = cellfun(@(c) strcmp(c,'l'), geometry.types);
     joint_logical = cellfun(@(c) strcmp(c,'j'), geometry.types);
@@ -41,13 +70,16 @@ function end_error_lae = error_chain(geometry, configuration, order)
         configuration = struct;
     end
     if any(link_logical) && ~isfield(configuration, 'links')
+        % assume links are as-given
         configuration.links = ones(1, sum(link_logical));
     end
     if any(joint_logical) && ~isfield(configuration, 'joints')
-        configuration.joints = ones(1, sum(joint_logical));
+        % assume reference for joints
+        configuration.joints = zeros(1, sum(joint_logical));
     end
     if any(error_logical) && ~isfield(configuration, 'errors')
-        configuration.errors = ones(1, sum(error_logical));
+        % assume reference for errors
+        configuration.errors = zeros(1, sum(error_logical));
     end
     
     %% construction of Lie Algebra elements
@@ -75,30 +107,125 @@ function end_error_lae = error_chain(geometry, configuration, order)
     algebras(joint_logical) = joints;
     algebras(error_logical) = errors;
     
-    %% symbolic math for error approximation
-    % create symbolic error term
-    dim = length(algebras{1}.vector);
-    sigma_vec = sym('sigma', [1, dim]);
-    sigma = AlgebraElement(sigma_vec);
-    % use BCH to write LHS, RHS
-    lhs_elements = [algebras(~error_logical) {sigma}];
-    LHS = BCH_n_elements(lhs_elements, order);
-    RHS = BCH_n_elements(algebras, order);
-    % solve for error, sigma
-    sigma_soln_struct = solve(LHS.vector == RHS.vector, sigma_vec);
-    sigma_soln_vec = subs(sigma_vec, sigma_soln_struct);
-    end_error_lae = AlgebraElement(sigma_soln_vec);
-    % exponentiate with T.S. approx.
-    end_error_lge = end_error_lae.to_GroupElement_Taylor(order);
-    
-    %% break solution apart in terms of errors
-    % break into terms: linear, bilinear, quadratic... (in ea. err)
-    % plot contributions (in an interactable plot environment?)
-    
-    % existing outputs:
-        % link configurations
-        % Jacobians of each link
-    % new outputs:
-        % error term(s)?
-        % plotted errors
+    %% error math
+    % check for error terms before jumping in
+    if any(error_logical)
+        %% symbolic math for error approximation
+        % create symbolic error term
+        dim = length(algebras{1}.vector);
+        sigma_vec = sym('sigma', [1, dim]);
+        assume(sigma_vec, 'real');
+        sigma = AlgebraElement(sigma_vec);
+        % use BCH to write LHS, RHS
+        lhs_elements = [algebras(~error_logical) {sigma}];
+        LHS = BCH_n_elements(lhs_elements, order);
+        RHS = BCH_n_elements(algebras, order);
+        % solve for error, sigma
+        sigma_soln_struct = solve(LHS.vector == RHS.vector, sigma_vec);
+        sigma_soln_vec = subs(sigma_vec, sigma_soln_struct);
+        end_error_lae = AlgebraElement(sigma_soln_vec);
+        % exponentiate
+        end_error_lge = end_error_lae.to_GroupElement_Taylor(order);
+        end_error_lge = end_error_lge.vector_small_angles();
+        %% create polynomial of error terms (to search)
+        % get supplied error variables vector
+        err_vars = [];
+        for e = 1:length(errors)
+            curr_vars = symvar(errors{e}.matrix);
+            exist_vars = ismember(curr_vars, err_vars);
+            err_vars = [err_vars curr_vars(~exist_vars)];
+        end
+        % create possible polynomial terms
+        full_poly = 1;
+        for v = 1:length(err_vars)
+            tmp_poly = 1;
+            for d = 1:truncate_to
+                tmp_poly = tmp_poly + err_vars(v)^d;
+            end
+            full_poly = full_poly*tmp_poly;
+        end
+        full_poly = expand(full_poly);
+        % represent as ind. terms; truncate to desired degree
+        expected_terms = children(full_poly);
+        t = 1;
+        while t <= length(expected_terms)
+            if polynomialDegree(expected_terms{t}) > truncate_to
+                expected_terms(t) = [];
+            else
+                t = t+1;
+            end
+        end
+        %% search for expected polynomial terms
+        % get terms in aggregate error matching expected terms
+        end_error_poly = expand(end_error_lge.vector);
+        end_error_terms = children(end_error_poly);
+        sep_error_terms = cell(size(expected_terms));
+        % searching for expected terms
+        for term = 1:length(expected_terms)
+            contribution = sym(zeros(size(end_error_terms,1),1));
+            % search along ea. dimension
+            for dim = 1:length(end_error_terms)
+                % inspect ea. term of full end error polynomial
+                for t = 1:length(end_error_terms{dim})
+                    unit_quantity = end_error_terms{dim}{t}/expected_terms{term};
+                    symvars = symvar(unit_quantity);
+                    % if this is correct term, should be no err. terms after
+                    % division
+                    curr_exist_err_vars = ismember(symvars, err_vars);
+                    if ~any(curr_exist_err_vars)
+                        contribution(dim) = contribution(dim) + end_error_terms{dim}{t};
+                    end
+                end
+            end
+            sep_error_terms{term} = contribution;
+        end
+    else
+        % no error terms; set outputs
+        end_error_lae = AlgebraElement(zeros(size(joints{1}.vector)));
+        end_error_lge = GroupElement(zeros(size(end_error_lae.vector)));
+        expected_terms = 0;
+        sep_error_terms = 0;
+    end
+    %% produce standard N_link_chain outputs (link configs, jacobians)
+    % pre-allocate storage for joint configs, Jacobians
+    joint_configurations = zeros(length(joints), length(joints{1}.vector));
+    J = zeros(size(joint_configurations, 2),...
+              size(joint_configurations,1),...
+              size(joint_configurations,1));
+    % keep track of current configuration (start as identity)
+    current_config = GroupElement(zeros(1,size(joint_configurations, 2)));
+    % count link/joint (for scalar indexing)
+    j = 1;
+    l = 1;
+    % iterate thru group elements
+    for e = 1:length(geometry.elements)
+        % if error, skip
+        if geometry.types{e} == 'e'
+            continue
+        % if link or joint, scale by supplied scalars
+        elseif geometry.types{e} == 'l'
+            trans_vec = geometry.elements{e}.vector*configuration.links(l);
+            l = l + 1;
+        elseif geometry.types{e} == 'j'
+            trans_vec = geometry.elements{e}.vector*configuration.joints(j);
+            % not incrementing j; will do later
+        end
+        % apply scaled transform to current config.
+        transform = GroupElement(trans_vec);
+        current_config = current_config.right_action(transform);
+        % for joints, save relevant data
+        if geometry.types{e} == 'j'
+            % save configuration
+            [current_config, conf_vec] = current_config.vector_true();
+            joint_configurations(j,:) = conf_vec';
+            % construct columns of J w.r.t base link
+            % done vector-wise (not group-wise) because I have a slow brain
+            for j_prev = 1:(j-1)
+                diff_vec = conf_vec' - joint_configurations(j_prev,:);
+                J(:, j_prev, j) = cross(diff_vec, joints{j_prev}.vector);
+            end
+            % increment joint index
+            j = j + 1;
+        end
+    end
 end

--- a/ProgramFiles/Test/error_chain_test.m
+++ b/ProgramFiles/Test/error_chain_test.m
@@ -1,0 +1,47 @@
+% test script for error_chain.m
+% may also be used a reference for use
+
+% test error handling
+disp('Errors:')
+% no geometry
+try
+    error_chain();
+catch e
+    disp(e.message);
+end
+% empty geometry
+geometry = struct;
+try
+    error_chain(geometry);
+catch e
+    disp(e.message);
+end
+% incorrect geometry elements
+geometry.elements = {1 2 3 4};
+geometry.types = cell(4);
+try
+    error_chain(geometry);
+catch e
+    disp(e.message);
+end
+% incorrect geometry types
+geometry.elements = {GroupElement.LINEAR};
+geometry.types = {1 2 3 4};
+try
+    error_chain(geometry);
+catch e
+    disp(e.message);
+end
+
+% construct planar error chain; get 1st order error
+geometry.elements = {GroupElement.ROTARY, GroupElement.ROTARY,...
+                     GroupElement.LINEAR};
+geometry.types = {'j', 'e', 'l'};
+configuration.errors = sym('theta');
+disp('Expect warning about order:');
+err_lae = error_chain(geometry, configuration);
+disp('End effector error LAE:');
+err_lae.vector
+
+
+

--- a/ProgramFiles/Test/error_chain_test.m
+++ b/ProgramFiles/Test/error_chain_test.m
@@ -1,6 +1,8 @@
 % test script for error_chain.m
 % may also be used a reference for use
 
+clear; clf;
+
 % test error handling
 disp('Errors:')
 % no geometry
@@ -33,15 +35,66 @@ catch e
     disp(e.message);
 end
 
-% construct planar error chain; get 1st order error
+% construct error chains
+disp([newline 'Rotary chain testing']);
 geometry.elements = {GroupElement.ROTARY, GroupElement.ROTARY,...
                      GroupElement.LINEAR};
 geometry.types = {'j', 'e', 'l'};
-configuration.errors = sym('theta');
-disp('Expect warning about order:');
-err_lae = error_chain(geometry, configuration);
-disp('End effector error LAE:');
-err_lae.vector
+syms theta;
+assume(theta, 'real');
+configuration.errors = theta;
+warning('on');
+disp('Warnings about order, truncate_to:');
+[~,~,expected_terms,sep_error_terms] = error_chain(geometry, configuration);
+warning('off');
+disp('First order error terms (default order, truncation):');
+display_terms(expected_terms,sep_error_terms);
+disp('First order error terms (correct order, truncation):');
+[~,~,expected_terms,sep_error_terms] = error_chain(geometry, configuration, 2, 1);
+display_terms(expected_terms,sep_error_terms);
+disp('Second order error terms:');
+[~,~,expected_terms,sep_error_terms] = error_chain(geometry, configuration, 3, 2);
+display_terms(expected_terms,sep_error_terms);
 
+disp([newline 'Rotary-Prismatic chain testing']);
+geometry.elements = {GroupElement.ROTARY, GroupElement.ROTARY,...
+                    GroupElement.LINEAR, GroupElement.LINEAR,...
+                    GroupElement.LINEAR};
+geometry.types = {'j','e','j','e','l'};
+syms x;
+assume(x, 'real');
+configuration.errors = [theta x];
+disp('First order error terms:');
+[~,~,expected_terms,sep_error_terms] = error_chain(geometry, configuration, 2, 1);
+display_terms(expected_terms,sep_error_terms);
+disp('Second order error terms:');
+[~,~,expected_terms,sep_error_terms] = error_chain(geometry, configuration, 3, 2);
+display_terms(expected_terms,sep_error_terms);
 
+% test N-link-chain outputs
+disp([newline 'Default output testing']);
+geometry.elements = {GroupElement.ROTARY, GroupElement.LINEAR,...
+                     GroupElement.ROTARY, GroupElement.LINEAR,...
+                     GroupElement.ROTARY};
+geometry.types = {'j','l','j','l','j'};
+configuration.joints = [pi/2, -pi/4, 0];
+[~, ~, ~, ~, joint_configurations, J] = error_chain(geometry, configuration);
+hold on
+line(joint_configurations(:,1), joint_configurations(:,2), 'Color', 'black', 'Marker', 'o')
+for j = 1:size(joint_configurations, 1)
+    for c = 1:size(J, 2)
+        quiver(joint_configurations(j,1), joint_configurations(j,2), J(1,c,j), J(2,c,j));
+    end
+end
+xlim([0 3.5]);
+ylim([0 3.5]);
+hold off
+
+% fn to display existent terms
+function display_terms(expected_terms, sep_error_terms)
+    for term = 1:length(expected_terms)
+        line = [char(expected_terms{term}), ': ', char(sep_error_terms{term}),';'];
+        disp(line);
+    end
+end
 

--- a/ProgramFiles/Utilities/kinematics/AlgebraElement.m
+++ b/ProgramFiles/Utilities/kinematics/AlgebraElement.m
@@ -1,0 +1,64 @@
+% generalization of a Lie Algebra element in SE(2) or SE(3)
+% almost a CC of GroupElement; copying and pasting code (bad practice)
+classdef AlgebraElement
+    properties
+        is_planar;
+        vector;
+        matrix;
+    end
+    
+    methods
+        % construct LA element
+        function obj = AlgebraElement(rep)
+            % sanitize inputs
+            if nargin == 0
+                rep = [0 0 0];
+            end
+            if isrow(rep)
+                rep = rep';
+            end
+            if size(rep,2) > 1
+                % rep is already a matrix
+                if length(rep) == 3
+                    obj.is_planar = true;
+                    obj.vector = [rep(1,3) rep(2,3) rep(2,1)]';
+                elseif length(rep) == 4
+                    obj.is_planar = false;
+                    obj.vector = [rep(1,4) rep(2,4) rep(3,4) rep(3,2) rep(1,3) rep(2,1)];
+                else
+                    error('AlgebraElement must be in SE(2) or SE(3)')
+                end
+                obj.matrix = rep;
+                return
+            else
+                % construct matrix
+                % do planar detection
+                if length(rep) == 3
+                    obj.is_planar = true;
+                elseif length(rep) == 6
+                    obj.is_planar = false;
+                else
+                    error('AlgebraElement must be in SE(2) or SE(3)')
+                end
+                if obj.is_planar
+                    obj.matrix = [0 -rep(3) rep(1);
+                                  rep(3) 0 rep(2);
+                                  0 0 0];
+                else
+                    obj.matrix = [0 -rep(6) rep(5) rep(1);
+                                  rep(6) 0 -rep(4) rep(2);
+                                  -rep(5) rep(4) 0 rep(3);
+                                  0 0 0 0];
+                end
+            end
+            obj.vector = rep;
+        end
+        % exponentiate to convert to group element
+        function lge = to_GroupElement(obj, time)
+            if ~exist('time','var')
+                time = 1;
+            end
+            lge = GroupElement(expm(time * obj.matrix));
+        end
+    end
+end

--- a/ProgramFiles/Utilities/kinematics/AlgebraElement.m
+++ b/ProgramFiles/Utilities/kinematics/AlgebraElement.m
@@ -54,11 +54,17 @@ classdef AlgebraElement
             obj.vector = rep;
         end
         % exponentiate to convert to group element
-        function lge = to_GroupElement(obj, time)
-            if ~exist('time','var')
-                time = 1;
+        function lge = to_GroupElement(obj)
+            lge = GroupElement(expm(obj.matrix));
+        end
+        function lge = to_GroupElement_Taylor(obj, order)
+            last = eye(size(obj.matrix));
+            res = last;
+            for k = 1:order
+                last = last*obj.matrix/k;
+                res = res + last;
             end
-            lge = GroupElement(expm(time * obj.matrix));
+            lge = GroupElement(res);
         end
     end
 end

--- a/ProgramFiles/Utilities/kinematics/BCH.m
+++ b/ProgramFiles/Utilities/kinematics/BCH.m
@@ -1,0 +1,20 @@
+% computes Baker-Campbell-Hausdorff terms and result for two AlgebraElements
+% pulled from https://en.wikipedia.org/wiki/Baker%E2%80%93Campbell%E2%80%93Hausdorff_formula#Explicit_forms
+function [Z, Z_terms] = BCH(x, y, num_terms)
+    % separate terms into cell array
+    % this is so we don't waste compute time on unused terms
+    z_series = {@(X,Y) X + Y,...
+                @(X,Y) 1/2*(X*Y - Y*X),...
+                @(X,Y) 1/12*(X^2*Y + X*Y^2 - 2*X*Y*X + Y^2*X + Y*X^2 - 2*Y*X*Y),...
+                @(X,Y) 1/24*(X^2*Y^2 - 2*X*Y*X*Y - Y^2*X^2 + 2*Y*X*Y*X)};
+    % compute each term, as well as aggregate
+    Z_mat = 0;
+    Z_terms = cell(1, num_terms);
+    for t = 1:num_terms
+        Z_term_func = z_series{t};
+        current_term = Z_term_func(x.matrix, y.matrix);
+        Z_terms{t} = AlgebraElement(current_term);
+        Z_mat = Z_mat + current_term;
+    end
+    Z = AlgebraElement(Z_mat);
+end

--- a/ProgramFiles/Utilities/kinematics/BCH_n_elements.m
+++ b/ProgramFiles/Utilities/kinematics/BCH_n_elements.m
@@ -1,0 +1,29 @@
+% computes Baker-Campbell-Hausdorff for n AlgebraElements
+function [Z, Z_terms] = BCH_n_elements(algebra_elements, num_terms)
+    % initialize storage of terms
+    Z_terms = cell(1, num_terms);
+    % enter first element just to bootstrap; this will be removed later
+    Z_terms(1) = algebra_elements(1);
+    % BCH is computed "nested" for ea. algebra element
+    for e = 2:length(algebra_elements)
+        terms_so_far = sum(~cellfun(@isempty, Z_terms));
+        for order = 1:terms_so_far
+            % BCH computed for ea. existing term to preserve knowledge of order
+            [~,intermediate_terms] = BCH(Z_terms{order}, algebra_elements{e}, num_terms);
+            % add resultant terms (of acceptable order) to existing terms
+            for t = 1:length(intermediate_terms)
+                if order+t-1 <= num_terms
+                    % shift index, such that elements are correct order
+                    Z_terms{order+t-1} = AlgebraElement(intermediate_terms{t}.vector);
+                end
+            end
+        end
+    end
+    % create resultant element from terms
+    % a cellfun would compact this, but I can't figure it out rn
+    Z_vec = zeros(1,length(Z_terms{1}.vector))';
+    for i = 1:length(Z_terms)
+        Z_vec = Z_vec + Z_terms{i}.vector;
+    end
+    Z = AlgebraElement(Z_vec);
+end

--- a/ProgramFiles/Utilities/kinematics/GroupElement.m
+++ b/ProgramFiles/Utilities/kinematics/GroupElement.m
@@ -75,15 +75,35 @@ classdef GroupElement
         end
         
         % group actions (convenience functions)
-        function obj = rightAction(obj, other)
+        function obj = right_action(obj, other)
             obj.matrix = obj.matrix * other.matrix;
             obj.vector = [];
             warning("GroupElement constructed from matrix; no vector representation available")
         end
-        function obj = leftAction(obj, other)
+        function obj = left_action(obj, other)
             obj.matrix = other.matrix * obj.matrix;
             obj.vector = [];
             warning("GroupElement constructed from matrix; no vector representation available")
+        end
+        
+        % constructs vector from SE matrix with small angle approximation
+        function [obj, vec] = vector_small_angles(obj)
+            if obj.is_planar
+                vec = [obj.matrix(1:2,3)' -obj.matrix(1,2)]';
+            else
+                angles = [obj.matrix(3,2) -obj.matrix(3,1) obj.matrix(2,1)];
+                vec = [obj.matrix(1:3,4)' angles]';
+            end
+            obj.vector = vec;
+        end
+        function [obj, vec] = vector_true(obj)
+            if obj.is_planar
+                vec = mat_to_vec_SE2(obj.matrix)';
+            else
+                angles = rotm2eul(obj.matrix(1:3, 1:3));
+                vec = [obj.matrix(1:3,4)', flip(angles)]';
+            end
+            obj.vector = vec;
         end
     end
     

--- a/ProgramFiles/Utilities/kinematics/GroupElement.m
+++ b/ProgramFiles/Utilities/kinematics/GroupElement.m
@@ -1,0 +1,92 @@
+% generalization of a Lie Group element in SE(2) or SE(3)
+classdef GroupElement
+    properties
+        is_planar;
+        vector;
+        matrix;
+    end
+    
+    %TODO: add basic transforms (rotation, displacement)
+    
+    methods
+        % produces a GroupElement with vector in 2D or 3D
+        function obj = GroupElement(rep)
+            % sanitize inputs
+            if nargin == 0
+                rep = [0 0 0];
+            end
+            if isrow(rep)
+                rep = rep';
+            end
+            % handle matrix construction
+            if size(rep,2) > 1
+                % rep is already a matrix; not setting vector
+                obj.matrix = rep;
+                warning("GroupElement constructed from matrix; no vector representation available")
+                % do planar detection
+                if length(obj.matrix) == 3
+                    obj.is_planar = true;
+                elseif length(obj.matrix) == 4
+                    obj.is_planar = false;
+                else
+                    error('GroupElement must be in SE(2) or SE(3)')
+                end
+                return
+            else
+                % construct matrix from vector
+                % do planar detection
+                if length(rep) == 3
+                    obj.is_planar = true;
+                elseif length(rep) == 6
+                    obj.is_planar = false;
+                else
+                    error('GroupElement must be in SE(2) or SE(3)')
+                end
+                if obj.is_planar
+                    % 2d case is trivial
+                    obj.matrix = [cos(rep(3)) -sin(rep(3)) rep(1);...
+                                  sin(rep(3)) cos(rep(3)) rep(2);...
+                                  0 0 1];
+                else
+                    % 3d case needs more complexity
+                    obj.matrix = [GroupElement.rot_mat_3d(rep(4:end)), rep(1:3); [0 0 0 1]];
+                end
+                % save vector for easy access
+                obj.vector = rep;
+            end
+        end
+        
+        % log to convert to Algebra element
+        function lae = to_AlgebraElement(obj)
+            lae = AlgebraElement(logm(obj.matrix));
+        end
+        
+        % group actions (convenience functions)
+        function obj = rightAction(obj, other)
+            obj.matrix = obj.matrix * other.matrix;
+            obj.vector = [];
+            warning("GroupElement constructed from matrix; no vector representation available")
+        end
+        function obj = leftAction(obj, other)
+            obj.matrix = other.matrix * obj.matrix;
+            obj.vector = [];
+            warning("GroupElement constructed from matrix; no vector representation available")
+        end
+    end
+    
+    methods(Static)
+        % produces a 3D rotation matrix, in YPR order
+        function R = rot_mat_3d(rot_vec)
+            Rx = [1 0 0;
+                  0 cos(rot_vec(1)) -sin(rot_vec(1));
+                  0 sin(rot_vec(1)) cos(rot_vec(1))];
+            Ry = [cos(rot_vec(2)) 0 sin(rot_vec(2));
+                  0 1 0;
+                  -sin(rot_vec(2)) 0 cos(rot_vec(2))];
+            Rz = [cos(rot_vec(3)) -sin(rot_vec(3)) 0;
+                  sin(rot_vec(3)) cos(rot_vec(3)) 0;
+                  0 0 1];
+            R = Rz * Ry * Rx;
+        end
+    end
+end

--- a/ProgramFiles/Utilities/kinematics/GroupElement.m
+++ b/ProgramFiles/Utilities/kinematics/GroupElement.m
@@ -1,12 +1,25 @@
 % generalization of a Lie Group element in SE(2) or SE(3)
 classdef GroupElement
+    % relevant representations
     properties
         is_planar;
         vector;
         matrix;
     end
     
-    %TODO: add basic transforms (rotation, displacement)
+    % static transforms, for convenience
+    properties (Constant)
+        % planar
+        LINEAR = GroupElement([1 0 0]);
+        ROTARY = GroupElement([0 0 1]);
+        % 3d
+        LINEAR_X = GroupElement([1 0 0 0 0 0]);
+        LINEAR_Y = GroupElement([0 1 0 0 0 0]);
+        LINEAR_Z = GroupElement([0 0 1 0 0 0]);
+        ROTARY_X = GroupElement([0 0 0 1 0 0]);
+        ROTARY_Y = GroupElement([0 0 0 0 1 0]);
+        ROTARY_Z = GroupElement([0 0 0 0 0 1]);
+    end
     
     methods
         % produces a GroupElement with vector in 2D or 3D


### PR DESCRIPTION
Adds:
- `AlgebraElement.m`
    - Class definition for Lie Algebra elements in SE(2) or SE(3)
    - Convenience methods for working with AlgebraElements
    - Conversions to GroupElements
- `GroupElement.m`
    - Class definition for Lie Group elements in SE(2) or SE(3)
    - Convenience methods for working with GroupElements
    - Conversions to AlgebraElements
- `BCH.m`
    - Computes Baker-Campbell-Hausdorff for two AlgebraElements, up to four terms
- `BCH_n_elements.m`
    - Computes Baker-Campbell-Hausdorff for an arbitrary number of elements, up to four terms
- `error_chain.m`
    - Generalizes definition of kinematic chains (Using AlgebraElement, GroupElement)
    - Accepts symvars
    - Computes approximation (and propagation) of error terms from joints to the end effector
    - Returns:
      - Expected error terms
      - Error approximation polynomials
      - Nominal configuration
      - Jacobians
- `error_chain_test.m`
    - Does unit testing of input sanitization
    - Qualitative tests for behavior